### PR TITLE
Replace Spree's `ErrorHandler` with `Rails.error`

### DIFF
--- a/app/services/spree_stripe/webhook_handlers/setup_intent_succeeded.rb
+++ b/app/services/spree_stripe/webhook_handlers/setup_intent_succeeded.rb
@@ -17,7 +17,7 @@ module SpreeStripe
             { api_key: spree_payment_method.preferred_secret_key }
           )
         rescue Stripe::StripeError => e
-          Rails.error.report(e, handled: false, context: { event: event, user: user }, source: 'spree_stripe')
+          Rails.error.report(e, handled: false, context: { event: event, user_id: user.id }, source: 'spree_stripe')
           return
         end
 

--- a/app/services/spree_stripe/webhook_handlers/setup_intent_succeeded.rb
+++ b/app/services/spree_stripe/webhook_handlers/setup_intent_succeeded.rb
@@ -17,7 +17,7 @@ module SpreeStripe
             { api_key: spree_payment_method.preferred_secret_key }
           )
         rescue Stripe::StripeError => e
-          Spree::Dependencies.error_handler.constantize.call(exception: e, opts: { report_context: { event: event }, user: user })
+          Rails.error.report(e, handled: false, context: { event: event, user: user }, source: 'spree_stripe')
           return
         end
 

--- a/lib/spree_stripe/version.rb
+++ b/lib/spree_stripe/version.rb
@@ -1,5 +1,5 @@
 module SpreeStripe
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 
   def gem_version
     Gem::Version.new(VERSION)


### PR DESCRIPTION
Spree PR: https://github.com/spree/spree/pull/12573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced error reporting with more structured context information to improve issue diagnosis and system reliability.

- **Tests**
  - Updated test expectations to align with the revamped error reporting approach.

- **Chores**
  - Updated the version number of the SpreeStripe module from 1.0.0 to 1.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->