### PR TITLE
Allow completing order from the API with succeeded payment intent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,14 @@ end
 
 gem 'rails-controller-testing'
 
-spree_opts = { github: 'spree/spree', branch: 'main' }
+spree_opts = if ENV['SPREE_PATH']
+                { 'path': ENV['SPREE_PATH'] }
+             else
+                { 'github': 'spree/spree', 'branch': 'main' }
+             end
 gem 'spree', spree_opts
-gem 'spree_emails', spree_opts
 gem 'spree_admin', spree_opts
+gem 'spree_emails', spree_opts
 gem 'spree_storefront', spree_opts
 
 if ENV['DB'] == 'mysql'

--- a/app/controllers/spree/api/v2/storefront/stripe/payment_intents_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/stripe/payment_intents_controller.rb
@@ -18,7 +18,7 @@ module Spree
                 spree_current_order,
                 stripe_gateway,
                 stripe_payment_method_id: stripe_payment_method_id,
-                off_session: permitted_attributes[:off_session] || false
+                off_session: permitted_attributes[:off_session].to_b || false
               )
 
               render_serialized_payload { serialize_resource(@payment_intent) }
@@ -38,7 +38,7 @@ module Spree
               spree_authorize! :update, spree_current_order, order_token
 
               @payment_intent = spree_current_order.payment_intents.find(params[:id])
-              @payment_intent.attributes = permitted_attributes
+              @payment_intent.attributes = permitted_attributes.except(:off_session)
               @payment_intent.save!
 
               render_serialized_payload { serialize_resource(@payment_intent) }

--- a/app/controllers/spree/api/v2/storefront/stripe/payment_intents_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/stripe/payment_intents_controller.rb
@@ -49,9 +49,7 @@ module Spree
 
               stripe_payment_intent = @payment_intent.stripe_payment_intent
 
-              if spree_current_order.completed?
-                render_error_payload(Spree.t(:order_already_completed))
-              elsif stripe_payment_intent.status == 'succeeded'
+              if stripe_payment_intent.status == 'succeeded'
                 spree_authorize! :update, spree_current_order, order_token
 
                 SpreeStripe::CompleteOrder.new(payment_intent: @payment_intent).call

--- a/app/serializers/spree/v2/storefront/payment_intent_serializer.rb
+++ b/app/serializers/spree/v2/storefront/payment_intent_serializer.rb
@@ -5,6 +5,10 @@ module Spree
         set_type :payment_intent
 
         attributes :stripe_id, :client_secret, :ephemeral_key_secret, :customer_id, :amount, :stripe_payment_method_id
+
+        belongs_to :order, serializer: Spree::V2::Storefront::OrderSerializer
+        belongs_to :payment_method, serializer: Spree::V2::Storefront::PaymentMethodSerializer
+        has_one :payment, serializer: Spree::V2::Storefront::PaymentSerializer
       end
     end
   end

--- a/app/services/spree_stripe/create_payment_intent.rb
+++ b/app/services/spree_stripe/create_payment_intent.rb
@@ -33,6 +33,7 @@ module SpreeStripe
         stripe_id: response.authorization,
         client_secret: response.params['client_secret'],
         customer_id: customer&.profile_id,
+        stripe_payment_method_id: stripe_payment_method_id,
         ephemeral_key_secret: ephemeral_key_secret
       )
     end

--- a/app/views/spree_stripe/_quick_checkout.html.erb
+++ b/app/views/spree_stripe/_quick_checkout.html.erb
@@ -25,7 +25,7 @@
       <div class="relative group-[.no-separator]:hidden flex py-5 items-center ">
         <div class="flex-grow border-t border-default"></div>
         <span class="flex-shrink mx-4 text-gray-500 text-sm">
-          <%= Spree.t(:or_continue_below) %>
+          <%= Spree.t('storefront.checkout.or_continue_below') %>
         </span>
         <div class="flex-grow border-t border-default"></div>
       </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -34,7 +34,7 @@ data:
     ## Example (replace %#= with %=):
     # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
     - "<%= %x[bundle info spree_core --path].chomp %>/config/locales/%{locale}.yml"
-
+    - "<%= %x[bundle info spree_storefront --path].chomp %>/config/locales/%{locale}.yml"
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,173 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `Dir.glob` patterns where translations are read from:
+  read:
+    ## Default:
+    - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+    - "<%= %x[bundle info spree_core --path].chomp %>/config/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `Find.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  strict: false
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ## - DefaultI18nSubjectMatcher
+  ##     Matches ActionMailer's default_i18n_subject method
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  # ast_matchers:
+  #   - 'I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher'
+  #   - 'I18n::Tasks::Scanners::AstMatchers::DefaultI18nSubjectMatcher'
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
+#   # deepl_glossary_ids:
+#   #   - f28106eb-0e06-489e-82c6-8215d6f95089
+#   #   - 2c6415be-1852-4f54-9e1b-d800463496b4
+#   # add additional options to the DeepL.translate call: https://www.deepl.com/docs-api/translate-text/translate-text/
+#   deepl_options:
+#     formality: prefer_less
+#   # OpenAI
+#   openai_api_key: "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+#   # openai_model: "gpt-3.5-turbo" # see https://platform.openai.com/docs/models
+#   # may contain `%{from}` and `%{to}`, which will be replaced by source and target locale codes, respectively (using `Kernel.format`)
+#   # openai_system_prompt: >-
+#   #   You are a professional translator that translates content from the %{from} locale
+#   #   to the %{to} locale in an i18n locale array.
+#   #
+#   #   The array has a structured format and contains multiple strings. Your task is to translate
+#   #   each of these strings and create a new array with the translated strings.
+#   #
+#   #   HTML markups (enclosed in < and > characters) must not be changed under any circumstance.
+#   #   Variables (starting with %%{ and ending with }) must not be changed under any circumstance.
+#   #
+#   #   Keep in mind the context of all the strings for a more accurate translation.
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+<% I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper', patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,14 +1,12 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
+---
 en:
   spree:
     stripe:
       payment_intent_errors:
-        requires_payment_method: "Payment intent requires payment method"
-        requires_confirmation: "Payment intent requires confirmation"
-        requires_action: "Payment intent requires action"
-        processing: "Payment intent processing"
-        requires_capture: "Payment intent requires capture"
-        canceled: "Payment intent canceled"
-        succeeded: "Payment intent succeeded"
+        canceled: Payment intent canceled
+        processing: Payment intent processing
+        requires_action: Payment intent requires action
+        requires_capture: Payment intent requires capture
+        requires_confirmation: Payment intent requires confirmation
+        requires_payment_method: Payment intent requires payment method
+        succeeded: Payment intent succeeded

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,8 +5,10 @@ en:
   spree:
     stripe:
       payment_intent_errors:
-        succeeded: "Payment intent succeeded"
-        processing: "Payment intent processing"
-        requires_action: "Payment intent requires action"
         requires_payment_method: "Payment intent requires payment method"
+        requires_confirmation: "Payment intent requires confirmation"
+        requires_action: "Payment intent requires action"
+        processing: "Payment intent processing"
+        requires_capture: "Payment intent requires capture"
         canceled: "Payment intent canceled"
+        succeeded: "Payment intent succeeded"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,11 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: "Hello world"
+  spree:
+    stripe:
+      payment_intent_errors:
+        succeeded: "Payment intent succeeded"
+        processing: "Payment intent processing"
+        requires_action: "Payment intent requires action"
+        requires_payment_method: "Payment intent requires payment method"
+        canceled: "Payment intent canceled"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Spree::Core::Engine.add_routes do
           resources :setup_intents, only: %i[create]
           resources :payment_intents, only: %i[show create update] do
             member do
-              post :confirm
+              patch :confirm
             end
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Spree::Core::Engine.add_routes do
       namespace :storefront do
         namespace :stripe do
           resources :setup_intents, only: %i[create]
-          resources :payment_intents, only: %i[show create update]
+          resources :payment_intents, only: %i[show create update] do
+            member do
+              post :confirm
+            end
+          end
         end
       end
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'i18n/tasks'
+
+RSpec.describe I18n do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  it 'files are normalized' do
+    non_normalized = i18n.non_normalized_paths
+    error_message = "The following files need to be normalized:\n" \
+                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                    "Please run `i18n-tasks normalize' to fix"
+    expect(non_normalized).to be_empty, error_message
+  end
+
+  it 'does not have inconsistent interpolations' do
+    error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
+                    "Run `i18n-tasks check-consistent-interpolations' to show them"
+    expect(inconsistent_interpolations).to be_empty, error_message
+  end
+end

--- a/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
@@ -8,18 +8,19 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
   let(:user) { nil }
 
   let(:headers) { { 'X-Spree-Order-Token' => order.token } }
-    let(:params) do
-      {
-        payment_intent: {
-          amount: amount,
-          stripe_payment_method_id: stripe_payment_method_id
-        }
+  let(:params) do
+    {
+      payment_intent: {
+        amount: amount,
+        stripe_payment_method_id: stripe_payment_method_id,
+        off_session: off_session
       }
-    end
+    }
+  end
 
   let(:amount) { 12.34 }
   let(:stripe_payment_method_id) { 'pm_1234567890' }
-
+  let(:off_session) { false }
   let(:stripe_response) do
     double(
       :stripe_response,
@@ -38,7 +39,7 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
       order.update(total: amount)
 
       allow_any_instance_of(gateway.class).to receive(:create_payment_intent)
-        .with(Spree::Money.new(amount).cents, order, payment_method_id: stripe_payment_method_id, off_session: false)
+        .with(Spree::Money.new(amount).cents, order, payment_method_id: stripe_payment_method_id, off_session: off_session)
         .and_return(stripe_response)
 
       post '/api/v2/storefront/stripe/payment_intents', headers: headers, params: params
@@ -61,6 +62,7 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
       expect(payment_intent.payment_method).to eq(gateway)
       expect(payment_intent.stripe_id).to eq(payment_intent_id)
       expect(payment_intent.client_secret).to eq(client_secret)
+      expect(payment_intent.stripe_payment_method_id).to eq(stripe_payment_method_id)
     end
   end
 

--- a/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
 
   describe 'payment_intents#confirm' do
     subject do
-      post "/api/v2/storefront/stripe/payment_intents/#{payment_intent.id}/confirm", headers: headers
+      patch "/api/v2/storefront/stripe/payment_intents/#{payment_intent.id}/confirm", headers: headers
     end
 
     let(:payment_intent) do

--- a/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
   let(:store) { Spree::Store.default }
 
   let!(:gateway) { create(:stripe_gateway, stores: [store]) }
-  let!(:order) { create(:order_with_line_items, user: nil) }
+  let!(:order) { create(:order_with_line_items, user: user) }
+  let(:user) { nil }
 
   let(:headers) { { 'X-Spree-Order-Token' => order.token } }
     let(:params) do
@@ -36,9 +37,9 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
     before do
       order.update(total: amount)
 
-      allow_any_instance_of(gateway.class).to receive(:create_payment_intent).
-        with(Spree::Money.new(amount).cents, order, payment_method_id: stripe_payment_method_id, off_session: false).
-        and_return(stripe_response)
+      allow_any_instance_of(gateway.class).to receive(:create_payment_intent)
+        .with(Spree::Money.new(amount).cents, order, payment_method_id: stripe_payment_method_id, off_session: false)
+        .and_return(stripe_response)
 
       post '/api/v2/storefront/stripe/payment_intents', headers: headers, params: params
     end
@@ -67,9 +68,9 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
     let(:payment_intent) { create(:payment_intent, stripe_id: payment_intent_id, order: order, payment_method: gateway) }
 
     before do
-      allow_any_instance_of(gateway.class).to receive(:update_payment_intent).
-        with(payment_intent.stripe_id, Spree::Money.new(amount).cents, order, stripe_payment_method_id).
-        and_return(stripe_response)
+      allow_any_instance_of(gateway.class).to receive(:update_payment_intent)
+        .with(payment_intent.stripe_id, Spree::Money.new(amount).cents, order, stripe_payment_method_id)
+        .and_return(stripe_response)
 
       patch "/api/v2/storefront/stripe/payment_intents/#{payment_intent.id}", headers: headers, params: params
     end
@@ -89,6 +90,164 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
       expect(payment_intent.payment_method).to eq(gateway)
       expect(payment_intent.stripe_id).to eq(payment_intent_id)
       expect(payment_intent.stripe_payment_method_id).to eq(stripe_payment_method_id)
+    end
+  end
+
+  describe 'payment_intents#confirm' do
+    subject do
+      post "/api/v2/storefront/stripe/payment_intents/#{payment_intent.id}/confirm", headers: headers
+    end
+
+    let(:payment_intent) do
+      order.payment_intents.create!(
+        amount: order.total,
+        payment_method: gateway,
+        stripe_id: payment_intent_id,
+        client_secret: client_secret
+      )
+    end
+    let!(:gateway_customer) { create(:gateway_customer, profile_id: 'cus_1234567890', user: user, payment_method: gateway) }
+    let(:user) { create(:user) }
+    let(:client_secret) { 'pi_123_secret_456' }
+    let(:stripe_payment_intent) do
+      Stripe::StripeObject.construct_from(
+        id: payment_intent_id,
+        status: 'requires_payment_method',
+        amount: (order.total * 100).to_i,
+        currency: 'usd',
+        client_secret: client_secret
+      )
+    end
+
+    before do
+      order.update_columns(state: 'payment', total: 10.0)
+      allow(Stripe::PaymentIntent).to receive(:retrieve).and_return(stripe_payment_intent)
+    end
+
+    context 'when order is canceled' do
+      before do
+        order.update_columns(state: 'canceled')
+        subject
+      end
+
+      it 'returns 404' do
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'when order is already completed' do
+      before do
+        order.update_columns(state: 'complete', completed_at: Time.current)
+        subject
+      end
+
+      it 'returns 404' do
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'when payment intent status is succeeded' do
+      let(:stripe_payment_intent) do
+        Stripe::StripeObject.construct_from(
+          id: payment_intent_id,
+          status: 'succeeded',
+          amount: (order.total * 100).to_i,
+          currency: 'usd',
+          customer: user.gateway_customers.last.profile_id,
+          latest_charge: 'ch_3QXRgr2ESifGlJez02SSg61f',
+          client_secret: client_secret
+        )
+      end
+
+      let(:stripe_charge) do
+        # TODO: Create factory for this
+        Stripe::StripeObject.construct_from(
+          id: 'ch_3QXRgr2ESifGlJez02SSg61f',
+          billing_details: {
+            name: 'John Doe',
+            email: 'john.doe@example.com',
+            phone: '+1234567890',
+            address: {
+              city: 'New York',
+              country: 'US'
+            }
+          },
+          payment_method_details: {
+            card: Stripe::StripeObject.construct_from(
+              brand: 'mastercard',
+              checks: Stripe::StripeObject.construct_from(
+                address_line1_check: 'unchecked',
+                address_postal_code_check: 'unchecked',
+                cvc_check: nil
+              ),
+              country: 'PL',
+              exp_month: 11,
+              exp_year: 2025,
+              fingerprint: 'FZqjhq46SWprIY8i',
+              funding: 'debit',
+              installments: nil,
+              last4: '3522',
+              mandate: nil,
+              network: 'mastercard',
+              three_d_secure: nil,
+              wallet: Stripe::StripeObject.construct_from(
+                apple_pay: nil,
+                dynamic_last4: '3139',
+                type: 'apple_pay'
+              )
+            ),
+            type: 'card'
+          },
+          payment_method: 'pm_1234567890'
+        )
+      end
+
+      before do
+        allow(Stripe::Charge).to receive(:retrieve).and_return(stripe_charge)
+        subject
+      end
+
+      it 'completes the order' do
+        expect(response.status).to eq(200)
+        expect(json_response['data']['type']).to eq('payment_intent')
+
+        expect(order.reload.completed?).to be(true)
+      end
+    end
+
+    context 'when payment intent has other status' do
+      before do
+        subject
+      end
+
+      it 'returns error message' do
+        expect(response.status).to eq(422)
+        expect(json_response['error']).to eq(Spree.t("stripe.payment_intent_errors.#{stripe_payment_intent.status}"))
+      end
+    end
+
+    context 'when gateway error occurs' do
+      let(:stripe_payment_intent) do
+        Stripe::StripeObject.construct_from(
+          id: payment_intent_id,
+          status: 'succeeded',
+          amount: (order.total * 100).to_i,
+          currency: 'usd',
+          charge: 'ch_3QXRgr2ESifGlJez02SSg61f',
+          client_secret: client_secret
+        )
+      end
+
+      before do
+        allow_any_instance_of(SpreeStripe::CompleteOrder).to receive(:call)
+          .and_raise(Spree::Core::GatewayError, 'Payment failed')
+        subject
+      end
+
+      it 'returns error message' do
+        expect(response.status).to eq(422)
+        expect(json_response['error']).to eq('Payment failed')
+      end
     end
   end
 end

--- a/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
 
     context 'when order is canceled' do
       before do
-        order.update_columns(state: 'canceled')
+        payment_intent.update(order: create(:order))
         subject
       end
 
@@ -143,8 +143,16 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
         subject
       end
 
-      it 'returns 404' do
-        expect(response.status).to eq(404)
+      it 'returns 422' do
+        expect(response.status).to eq(422)
+        expect(json_response['error']).to eq(Spree.t('order_already_completed'))
+      end
+    end
+
+    context "when payment intent's order is not the current order" do
+      before do
+        order.update_columns(state: 'payment', total: 10.0)
+        subject
       end
     end
 

--- a/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
@@ -151,8 +151,12 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
 
     context "when payment intent's order is not the current order" do
       before do
-        order.update_columns(state: 'payment', total: 10.0)
+        payment_intent.update(order: create(:order))
         subject
+      end
+
+      it 'returns 404' do
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/serializers/spree/v2/storefront/payment_intent_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/payment_intent_serializer_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe Spree::V2::Storefront::PaymentIntentSerializer do
+  subject { described_class.new(payment_intent).serializable_hash }
+
+  include_context 'API v2 serializers params'
+
+  let(:payment) { create(:payment) }
+  let(:payment_intent) { create(:payment_intent, payment: payment, payment_method: payment.payment_method) }
+
+  it 'serializes the payment intent' do
+    expect(subject).to eq(
+      {
+        data: {
+          type: :payment_intent,
+          attributes: {
+            stripe_id: payment_intent.stripe_id,
+            client_secret: payment_intent.client_secret,
+            ephemeral_key_secret: payment_intent.ephemeral_key_secret,
+            customer_id: payment_intent.customer_id,
+            amount: payment_intent.amount,
+            stripe_payment_method_id: payment_intent.stripe_payment_method_id
+          },
+          id: payment_intent.id.to_s,
+          relationships: {
+            order: {
+              data: {
+                id: payment_intent.order.id.to_s,
+                type: :order
+              }
+            },
+            payment_method: {
+              data: {
+                id: payment_intent.payment_method.id.to_s,
+                type: :payment_method
+              }
+            },
+            payment: {
+              data: {
+                id: payment_intent.payment.id.to_s,
+                type: :payment
+              }
+            }
+          }
+        }
+      }
+    )
+  end
+end

--- a/spec/services/spree_stripe/create_payment_intent_spec.rb
+++ b/spec/services/spree_stripe/create_payment_intent_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe SpreeStripe::CreatePaymentIntent, vcr: true do
-  let(:store) { Spree::Store.default }
-  let!(:gateway) { create(:stripe_gateway, stores: [store]) }
+  subject(:payment_intent) { described_class.new.call(order, gateway, stripe_payment_method_id: stripe_payment_method_id, off_session: off_session) }
 
-  subject { described_class.new.call(order, gateway) }
+  let(:store) { Spree::Store.default }
+  let(:stripe_payment_method_id) { 'pm_card_visa' }
+  let(:off_session) { false }
+  let!(:gateway) { create(:stripe_gateway, stores: [store]) }
+  let(:order) { create(:order, total: 10.00, store: store, state: :payment) }
 
   context 'when order is not valid' do
     let(:order) { create(:order, total: 10.00, store: store, state: :delivery, bill_address: nil, ship_address: nil) }
@@ -13,7 +16,19 @@ RSpec.describe SpreeStripe::CreatePaymentIntent, vcr: true do
     it 'still creates a payment intent' do
       order.ship_address = Spree::Address.new(country: store.default_country)
       expect(order.valid?).to be false
-      expect(subject).to be_present
+      expect(payment_intent).to be_present
     end
+  end
+
+  it 'saves payment intent in the database' do
+    expect(payment_intent).to be_persisted
+
+    expect(payment_intent.stripe_payment_method_id).to eq(stripe_payment_method_id)
+    expect(payment_intent.amount).to eq(order.total)
+    expect(payment_intent.client_secret).to be_present
+    expect(payment_intent.customer_id).to be_present
+    expect(payment_intent.ephemeral_key_secret).to be_present
+    expect(payment_intent.order).to eq(order)
+    expect(payment_intent.payment_method).to eq(gateway)
   end
 end

--- a/spec/vcr/SpreeStripe_CreatePaymentIntent/saves_payment_intent_in_the_database.yml
+++ b/spec/vcr/SpreeStripe_CreatePaymentIntent/saves_payment_intent_in_the_database.yml
@@ -1,0 +1,382 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: address[city]=Herndon&address[line1]=1+Lovely+Street&address[line2]=Northwest&address[postal_code]=35005&address[country]=United+States+of+America&email=nona%40jaskolski.ca&name=John+Doe
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.1.0 Spree Stripe/5.0.0.alpha (https://spreecommerce.org)
+      Authorization:
+      - Bearer <STRIPE_SECRET_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<FILTERED>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 Apr 2025 14:10:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '806'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YEPrHoXzUsspeM1sILvTOrJc8SqgCZaUpcTL49yQG-vMl5TxExpViBGi2M2fFeNpzGMVGNfTjnlXrfpO
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 7e784452-bfe9-4826-bfd6-a607f687f634
+      Original-Request:
+      - req_OjRu7V5jecRDlM
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_OjRu7V5jecRDlM
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHI
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_S3Z8np7zYxsOjB",
+          "object": "customer",
+          "address": {
+            "city": "Herndon",
+            "country": "United States of America",
+            "line1": "1 Lovely Street",
+            "line2": "Northwest",
+            "postal_code": "35005",
+            "state": null
+          },
+          "balance": 0,
+          "created": 1743603020,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "nona@jaskolski.ca",
+          "invoice_prefix": "AFF18C57",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": "John Doe",
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Wed, 02 Apr 2025 14:10:20 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: payment_method=pm_card_visa&off_session=false&confirm=false&amount=1000&customer=cus_S3Z8np7zYxsOjB&currency=USD&statement_descriptor_suffix=R026141440+Spree+Test&automatic_payment_methods[enabled]=true&transfer_group=R026141440&metadata[spree_order_id]=1
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.1.0 Spree Stripe/5.0.0.alpha (https://spreecommerce.org)
+      Authorization:
+      - Bearer <STRIPE_SECRET_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_OjRu7V5jecRDlM","request_duration_ms":441}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<FILTERED>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 Apr 2025 14:10:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1787'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=OiI0_paCJHcCh_BntrsPy0Xw4ez-wX2Q2LHU1q4ikmVBK8jxXcpzjTa5B8UCZCPCR3EA3wvMbyHmXrHe
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 88b0971d-564b-4c64-8e6f-b3028763df55
+      Original-Request:
+      - req_ycBew2kCgq1GiS
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_ycBew2kCgq1GiS
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHI
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3R9RzlFgg8qhioDX1hSkDp52",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": {
+            "allow_redirects": "always",
+            "enabled": true
+          },
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3R9RzlFgg8qhioDX1hSkDp52_secret_o1TaTFDpB6xFKan5VsVCuwuVz",
+          "confirmation_method": "automatic",
+          "created": 1743603021,
+          "currency": "usd",
+          "customer": "cus_S3Z8np7zYxsOjB",
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "metadata": {
+            "spree_order_id": "1"
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1R9RzlFgg8qhioDXe4td1bw0",
+          "payment_method_configuration_details": {
+            "id": "pmc_1KbPpJFgg8qhioDXAajuQrIY",
+            "parent": null
+          },
+          "payment_method_options": {
+            "alipay": {},
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            },
+            "klarna": {
+              "preferred_locale": null
+            },
+            "link": {
+              "persistent_token": null
+            },
+            "wechat_pay": {
+              "app_id": null,
+              "client": null
+            }
+          },
+          "payment_method_types": [
+            "card",
+            "alipay",
+            "klarna",
+            "link",
+            "wechat_pay"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "R026141440 Spree Test",
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": "R026141440"
+        }
+  recorded_at: Wed, 02 Apr 2025 14:10:21 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/ephemeral_keys
+    body:
+      encoding: UTF-8
+      string: customer=cus_S3Z8np7zYxsOjB
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.1.0 Spree Stripe/5.0.0.alpha (https://spreecommerce.org)
+      Authorization:
+      - Bearer <STRIPE_SECRET_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ycBew2kCgq1GiS","request_duration_ms":587}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<FILTERED>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 Apr 2025 14:10:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '353'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=OiI0_paCJHcCh_BntrsPy0Xw4ez-wX2Q2LHU1q4ikmVBK8jxXcpzjTa5B8UCZCPCR3EA3wvMbyHmXrHe
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 5824b54d-7118-45df-ba32-7f98d5ba1c26
+      Original-Request:
+      - req_nkJUhJYhwh9WHX
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_nkJUhJYhwh9WHX
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHI
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ephkey_1R9RzlFgg8qhioDXcS4bthWX",
+          "object": "ephemeral_key",
+          "associated_objects": [
+            {
+              "id": "cus_S3Z8np7zYxsOjB",
+              "type": "customer"
+            }
+          ],
+          "created": 1743603021,
+          "expires": 1743606621,
+          "livemode": false,
+          "secret": "ek_test_YWNjdF8xS1RqOVZGZ2c4cWhpb0RYLEZpa0RmbXlpeHJMN3Jxb0EwNTJxZGV0QllycUtLZEs_00o7OVTJ9d"
+        }
+  recorded_at: Wed, 02 Apr 2025 14:10:21 GMT
+recorded_with: VCR 6.3.1

--- a/spree_stripe.gemspec
+++ b/spree_stripe.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'spree_dev_tools'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
+  s.add_development_dependency 'i18n-tasks'
 end


### PR DESCRIPTION
Requires this Spree PR to be merged https://github.com/spree/spree/pull/12592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new payment confirmation action that refines the payment flow.
  - Enhanced payment creation with explicit handling for payment method identifiers and off-session parameters.

- **Localization & UI Improvements**
  - Updated error messages for various payment statuses for clearer user feedback.
  - Revised checkout translation keys to ensure more precise display text.
  - Added a new configuration file for managing internationalization tasks.

- **Tests & Chores**
  - Expanded test coverage for payment processing and internationalization.
  - Added configuration enhancements to support improved system consistency.
  - Introduced a new test suite for the payment intent serializer.
  - Added a new test for validating payment intent attributes in the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->