### PR TITLE
Add `publishable_key` in the payment_method serializer 

### DIFF
--- a/app/serializers/spree_stripe/v2/storefront/payment_method_serializer_decorator.rb
+++ b/app/serializers/spree_stripe/v2/storefront/payment_method_serializer_decorator.rb
@@ -1,0 +1,15 @@
+module SpreeStripe
+  module V2
+    module Storefront
+      module PaymentMethodSerializerDecorator
+        def self.prepended(base)
+          base.attribute :publishable_key do |pm|
+            pm.try(:preferred_publishable_key)
+          end
+        end
+      end
+    end
+  end
+end
+
+Spree::V2::Storefront::PaymentMethodSerializer.prepend(SpreeStripe::V2::Storefront::PaymentMethodSerializerDecorator)

--- a/spec/serializers/spree_stripe/v2/storefront/payment_method_serializer_spec.rb
+++ b/spec/serializers/spree_stripe/v2/storefront/payment_method_serializer_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Spree::V2::Storefront::PaymentMethodSerializer do
+  include_context 'API v2 serializers params'
+
+  subject { described_class.new(resource, params: serializer_params) }
+
+  let!(:store) { Spree::Store.default }
+  let(:resource) { create(:stripe_gateway) }
+
+  it { expect(subject.serializable_hash).to be_kind_of(Hash) }
+
+  it do
+    expect(subject.serializable_hash).to eq(
+      {
+        data: {
+          id: resource.id.to_s,
+          type: :payment_method,
+          attributes: {
+            name: resource.name,
+            description: resource.description,
+            type: resource.type,
+            publishable_key: resource.preferred_publishable_key,
+            preferences: {},
+            public_metadata: {},
+          },
+        }
+      }
+    )
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced payment method data by adding a new attribute that displays the publishable key.
- **Tests**
  - Introduced tests to verify the updated structure and accuracy of the payment method information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->