### PR TITLE
V-3090 FIX api url in stripe controller

### DIFF
--- a/app/javascript/spree_stripe/controllers/stripe_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_controller.js
@@ -10,7 +10,8 @@ export default class extends Controller {
     orderToken: String,
     colorPrimary: String,
     colorBackground: String,
-    colorText: String
+    colorText: String,
+    storeUrl: String
   }
 
   static targets = [
@@ -52,7 +53,7 @@ export default class extends Controller {
     }
 
     const response = await fetch(
-      `/api/v2/storefront/stripe/payment_intents/${this.paymentIntentValue.id}`,
+      `${this.storeUrlValue}/api/v2/storefront/stripe/payment_intents/${this.paymentIntentValue.id}`,
       {
         method: 'PATCH',
         headers: this.spreeApiHeaders,
@@ -178,7 +179,7 @@ export default class extends Controller {
 
   async validateOrderForPayment() {
     const response = await fetch(
-      '/api/v2/storefront/checkout/validate_order_for_payment',
+      `${this.storeUrlValue}/api/v2/storefront/checkout/validate_order_for_payment`,
       {
         method: 'POST',
         headers: this.spreeApiHeaders
@@ -203,7 +204,7 @@ export default class extends Controller {
   async updateBillingAddress() {
     // billing address same as shipping address
     if (this.billingAddressCheckbox.checked) {
-      const response = await fetch('/api/v2/storefront/checkout?include=billing_address', {
+      const response = await fetch(`${this.storeUrlValue}/api/v2/storefront/checkout?include=billing_address`, {
         method: 'PATCH',
         headers: this.spreeApiHeaders,
         body: JSON.stringify({
@@ -227,7 +228,7 @@ export default class extends Controller {
     if (this.billingAddressForm.checkValidity()) {
       const formData = new FormData(this.billingAddressForm);
 
-      const response = await fetch('/api/v2/storefront/checkout?include=billing_address', {
+      const response = await fetch(`${this.storeUrlValue}/api/v2/storefront/checkout?include=billing_address`, {
         method: 'PATCH',
         headers: this.spreeApiHeaders,
         body: JSON.stringify({

--- a/app/views/spree/checkout/payment/_spree_stripe.html.erb
+++ b/app/views/spree/checkout/payment/_spree_stripe.html.erb
@@ -7,6 +7,7 @@
   data-checkout-stripe-order-email-value="<%= @order.email %>"
   data-checkout-stripe-color-primary-value="<%= hex_color_to_rgb(theme_setting(:primary_color)) %>"
   data-checkout-stripe-color-text-value="<%= hex_color_to_rgb(theme_setting(:text_color)) %>"
+  data-checkout-stripe-store-url-value="<%= current_store.formatted_url_or_custom_domain %>"
 >
   <% payment_sources = checkout_payment_sources(payment_method) %>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stripe checkout now dynamically uses the store's URL for all payment-related API requests, improving compatibility with custom domains and store configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->