### PR TITLE
V-3062 FIX validate gift card path

### DIFF
--- a/app/javascript/spree_stripe/controllers/stripe_button_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_button_controller.js
@@ -234,7 +234,7 @@ export default class extends Controller {
       return
     }
 
-    if (this.giftCardCodeValue && this.giftCardAmountValue) {
+    if (this.giftCardCodeValue && this.giftCardAmountValue && this.checkoutValidateGiftCardDataPathValue) {
       const giftCardValidationResponse = await fetch(
         this.checkoutValidateGiftCardDataPathValue,
         {

--- a/app/views/spree_stripe/_quick_checkout.html.erb
+++ b/app/views/spree_stripe/_quick_checkout.html.erb
@@ -20,7 +20,7 @@
         checkout_stripe_button_checkout_path_value: spree.api_v2_storefront_checkout_path,
         checkout_stripe_button_checkout_advance_path_value: spree.advance_api_v2_storefront_checkout_path,
         checkout_stripe_button_checkout_select_shipping_method_path_value: spree.select_shipping_method_api_v2_storefront_checkout_path,
-        checkout_stripe_button_checkout_validate_gift_card_data_path_value: spree.api_v2_storefront_checkout_validate_gift_card_data_path,
+        checkout_stripe_button_checkout_validate_gift_card_data_path_value: spree.validate_gift_card_data_api_v2_storefront_checkout_path,
         checkout_stripe_button_checkout_validate_order_for_payment_path_value: spree.validate_order_for_payment_api_v2_storefront_checkout_path,
         checkout_stripe_button_return_url_value: spree.stripe_payment_intent_url(current_stripe_payment_intent)
       } do %>

--- a/app/views/spree_stripe/_quick_checkout.html.erb
+++ b/app/views/spree_stripe/_quick_checkout.html.erb
@@ -20,7 +20,7 @@
         checkout_stripe_button_checkout_path_value: spree.api_v2_storefront_checkout_path,
         checkout_stripe_button_checkout_advance_path_value: spree.advance_api_v2_storefront_checkout_path,
         checkout_stripe_button_checkout_select_shipping_method_path_value: spree.select_shipping_method_api_v2_storefront_checkout_path,
-        checkout_stripe_button_checkout_validate_gift_card_data_path_value: spree.validate_gift_card_data_api_v2_storefront_checkout_path,
+        checkout_stripe_button_checkout_validate_gift_card_data_path_value: respond_to?(:validate_gift_card_data_api_v2_storefront_checkout_path) ? spree.validate_gift_card_data_api_v2_storefront_checkout_path : nil,
         checkout_stripe_button_checkout_validate_order_for_payment_path_value: spree.validate_order_for_payment_api_v2_storefront_checkout_path,
         checkout_stripe_button_return_url_value: spree.stripe_payment_intent_url(current_stripe_payment_intent)
       } do %>


### PR DESCRIPTION
Merge after: https://github.com/spree/spree/pull/12737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gift card validation during Stripe quick checkout to prevent errors when validation is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->