### PR TITLE
Remove unused factory

### DIFF
--- a/lib/spree_stripe/testing_support/factories/payment_source_factory.rb
+++ b/lib/spree_stripe/testing_support/factories/payment_source_factory.rb
@@ -1,8 +1,0 @@
-FactoryBot.define do
-  factory :payment_source, class: Spree::PaymentSource do
-    association :payment_method, factory: :payment_method
-    gateway_payment_profile_id { 'pm_1adfg34fgfdf5245' }
-    type { 'SpreeStripe::PaymentSources::Alipay' }
-    user
-  end
-end


### PR DESCRIPTION
which is also defined in Spree 5.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed test factory for Stripe payment source objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->