### PR TITLE
Allow refreshing payment intents, update payment intent statement descriptor

### DIFF
--- a/app/models/spree_stripe/gateway.rb
+++ b/app/models/spree_stripe/gateway.rb
@@ -185,7 +185,7 @@ module SpreeStripe
           order: order,
           customer: fetch_or_create_customer(order: order)&.profile_id,
           payment_method_id: payment_method_id
-        ).call.slice(:amount, :currency, :payment_method, :shipping, :customer)
+        ).call.slice(:amount, :currency, :payment_method, :shipping, :customer, :statement_descriptor_suffix)
 
         response = send_request { Stripe::PaymentIntent.update(payment_intent_id, payload) }
 

--- a/app/models/spree_stripe/order_decorator.rb
+++ b/app/models/spree_stripe/order_decorator.rb
@@ -4,6 +4,14 @@ module SpreeStripe
       base.has_many :payment_intents, class_name: 'SpreeStripe::PaymentIntent', dependent: :destroy
     end
 
+    def refresh_payment_intents
+      return if completed?
+
+      payment_intents.each do |payment_intent|
+        payment_intent.update_stripe_payment_intent
+      end
+    end
+
     def update_payment_intents
       return if completed?
       return unless total_minus_store_credits.positive?

--- a/lib/spree_stripe/testing_support/factories/payment_source_factory.rb
+++ b/lib/spree_stripe/testing_support/factories/payment_source_factory.rb
@@ -1,8 +1,0 @@
-FactoryBot.define do
-  factory :payment_source, class: Spree::PaymentSource do
-    association :payment_method, factory: :payment_method
-    gateway_payment_profile_id { 'pm_1adfg34fgfdf5245' }
-    type { 'SpreeStripe::PaymentSources::Alipay' }
-    user
-  end
-end

--- a/spec/models/spree_stripe/order_decorator_spec.rb
+++ b/spec/models/spree_stripe/order_decorator_spec.rb
@@ -14,6 +14,36 @@ RSpec.describe SpreeStripe::OrderDecorator do
     expect(order.payment_intents).to eq([payment_intent])
   end
 
+  describe '#refresh_payment_intents' do
+    context 'when the order is not completed' do
+      it 'updates the payment intent' do
+        expect(Stripe::PaymentIntent).to receive(:update).with(payment_intent.stripe_id, anything).and_return(double(id: payment_intent.stripe_id))
+        order.refresh_payment_intents
+      end
+
+      context 'with multiple payment intents' do
+        let!(:second_payment_intent) { create(:payment_intent, order: order, payment_method: stripe_gateway, amount: order.total_minus_store_credits, stripe_id: 'pi_different_id') }
+
+        before { order.reload }
+
+        it 'updates all payment intents' do
+          expect(Stripe::PaymentIntent).to receive(:update).with(payment_intent.stripe_id, anything).and_return(double(id: payment_intent.stripe_id))
+          expect(Stripe::PaymentIntent).to receive(:update).with(second_payment_intent.stripe_id, anything).and_return(double(id: second_payment_intent.stripe_id))
+          order.refresh_payment_intents
+        end
+      end
+    end
+
+    context 'when the order is completed' do
+      let(:order) { create(:order_with_line_items, store: store, user: user, state: :complete, completed_at: Time.current) }
+
+      it 'does not update payment intents' do
+        expect(Stripe::PaymentIntent).not_to receive(:update)
+        order.refresh_payment_intents
+      end
+    end
+  end
+
   it "updates the payment intent when the order is updated" do
     # order updater runs twice during recalculate
     expect(Stripe::PaymentIntent).to receive(:update).twice.and_return(double(id: payment_intent.stripe_id))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to refresh payment intents on orders that are not completed.

- **Bug Fixes**
  - Improved payment intent updates to support additional attributes during Stripe updates.

- **Tests**
  - Added tests to verify correct behavior of payment intent refresh functionality.

- **Chores**
  - Removed an unused test factory for payment sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->