### PR TITLE
Improve quick checkout with digital items

### DIFF
--- a/app/javascript/spree_stripe/controllers/stripe_button_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_button_controller.js
@@ -117,21 +117,15 @@ export default class extends Controller {
         ]
       })
     })
-    prButton.on('shippingaddresschange', this.handleAddressChange.bind(this))
-    prButton.on('shippingratechange', this.handleShippingOptionChange.bind(this))
+    if (this.shippingRequiredValue) {
+      prButton.on('shippingaddresschange', this.handleAddressChange.bind(this))
+      prButton.on('shippingratechange', this.handleShippingOptionChange.bind(this))
+    }
     prButton.on('confirm', this.handleFinalizePayment.bind(this))
     prButton.on('cancel', this.handleCancelPayment.bind(this))
   }
 
   async handleAddressChange(ev) {
-    if (!this.shippingRequiredValue) {
-      ev.resolve({
-        shippingRates: [],
-        lineItems: this.buildLineItems({ data: { attributes: { total_minus_store_credits_cents: this.amountValue } } })
-      })
-      return
-    }
-
     // Perform server-side request to fetch shipping options
     // https://stripe.com/docs/js/payment_request/events/on_shipping_address_change#payment_request_on_shipping_address_change-handler-shippingAddress
     const orderUpdatePayload = {
@@ -200,11 +194,6 @@ export default class extends Controller {
   }
 
   async handleShippingOptionChange(ev) {
-    if (!this.shippingRequiredValue) {
-      ev.resolve()
-      return
-    }
-
     const { resolve, shippingRate, reject } = ev
 
     if (shippingRate) {
@@ -243,7 +232,7 @@ export default class extends Controller {
       shippingRateId = String(shippingRateId).replace(/_google_pay_\d+/, '')
     }
 
-    if (!shippingRateId || shippingRateId === 'loading') {
+    if (this.shippingRequiredValue && (!shippingRateId || shippingRateId === 'loading')) {
       ev.paymentFailed({ reason: 'invalid_shipping_address' })
       return
     }

--- a/app/views/spree_stripe/_quick_checkout.html.erb
+++ b/app/views/spree_stripe/_quick_checkout.html.erb
@@ -22,7 +22,8 @@
         checkout_stripe_button_checkout_select_shipping_method_path_value: spree.select_shipping_method_api_v2_storefront_checkout_path,
         checkout_stripe_button_checkout_validate_gift_card_data_path_value: respond_to?(:validate_gift_card_data_api_v2_storefront_checkout_path) ? spree.validate_gift_card_data_api_v2_storefront_checkout_path : nil,
         checkout_stripe_button_checkout_validate_order_for_payment_path_value: spree.validate_order_for_payment_api_v2_storefront_checkout_path,
-        checkout_stripe_button_return_url_value: spree.stripe_payment_intent_url(current_stripe_payment_intent)
+        checkout_stripe_button_return_url_value: spree.stripe_payment_intent_url(current_stripe_payment_intent),
+        checkout_stripe_button_shipping_required_value: @order.respond_to?(:quick_checkout_require_address?) ? @order.quick_checkout_require_address? : true
       } do %>
       <div id="payment-request-button"></div>
 


### PR DESCRIPTION
do not require shipping address when not needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for conditionally requiring shipping information during Stripe checkout based on the order's requirements.

- **Bug Fixes**
  - Improved handling of shipping address and shipping rates to skip shipping steps when not needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->