### PR TITLE
Do not require `billingAddressChecbox` to be present on the page

### DIFF
--- a/app/javascript/spree_stripe/controllers/stripe_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_controller.js
@@ -205,7 +205,7 @@ export default class extends Controller {
 
   async updateBillingAddress() {
     // billing address same as shipping address
-    if (this.billingAddressCheckbox.checked) {
+    if (this.billingAddressCheckbox?.checked) {
       const response = await fetch(`${this.checkoutPathValue}?include=billing_address`, {
         method: 'PATCH',
         headers: this.spreeApiHeaders,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when updating the billing address by preventing errors if the billing address checkbox is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->