### PR TITLE
ADD flash message on stripe checkout

### DIFF
--- a/app/javascript/spree_stripe/controllers/stripe_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_controller.js
@@ -222,7 +222,8 @@ export default class extends Controller {
       if (response.ok) {
         return responseJson.included.find(item => item.type === 'address').attributes;
       } else {
-        showFlashMessage(responseJson.error, 'error');
+        const errors = Array.isArray(responseJson.error) ? responseJson.error.join('. ') : responseJson.error || 'Billing address is invalid';
+        showFlashMessage(errors, 'error');
         this.submitTarget.disabled = false;
         return false;
       }
@@ -261,11 +262,6 @@ export default class extends Controller {
       } else {
         const errors = Array.isArray(responseJson.error) ? responseJson.error.join('. ') : responseJson.error || 'Billing address is invalid';
         showFlashMessage(errors, 'error');
-
-        const flashMessage = document.getElementsByClassName('flash-message')[0];
-        if (flashMessage) {
-          flashMessage.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
-        }
 
         this.submitTarget.disabled = false;
         return false;


### PR DESCRIPTION
<img width="1511" height="759" alt="Zrzut ekranu 2025-07-15 o 13 09 36" src="https://github.com/user-attachments/assets/bcfc131e-464a-41ff-9284-522a682b2b57" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by displaying an immediate error message to users when updating the billing address fails.
  * Removed automatic scrolling to error messages for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->