### PR TITLE
CHG stripe default queue

### DIFF
--- a/lib/spree_stripe.rb
+++ b/lib/spree_stripe.rb
@@ -8,7 +8,9 @@ require 'stripe'
 require 'stripe_event'
 
 module SpreeStripe
+  mattr_accessor :queue
+
   def self.queue
-    'spree_stripe'
+    @@queue ||= Spree.queues.default
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Stripe integration now uses the platform’s default background job queue by default and supports configuring a custom queue name. This enables better alignment with existing job processing setups and easier tuning for performance or isolation.
  * Provides a simple configuration entry to override the queue if desired, without requiring code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->