### PR TITLE
ADD optional params to stripe controller to modify payment element

### DIFF
--- a/app/javascript/spree_stripe/controllers/stripe_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_controller.js
@@ -13,7 +13,8 @@ export default class extends Controller {
     colorText: String,
     paymentIntentPath: String,
     checkoutPath: String,
-    checkoutValidateOrderForPaymentPath: String
+    checkoutValidateOrderForPaymentPath: String,
+    paymentElementAdditionalOptions: Object
   }
 
   static targets = [
@@ -96,7 +97,8 @@ export default class extends Controller {
               postalCode: 'never'
             }
           }
-        }
+        },
+        ...this.paymentElementAdditionalOptionsValue
       })
       paymentElement.mount(this.paymentElementTarget)
       paymentElement.on('change', (event) => {


### PR DESCRIPTION
By that we can pass Stripe's additional options like: 
`data-checkout-stripe-payment-element-additional-options-value="<%= { terms: { card: 'never' } }.to_json if @order.store.preferred_hide_payment_terms %>"
`
https://docs.stripe.com/js/elements_object/create_payment_element#payment_element_create-options-terms