### PR TITLE
Create Stripe Tax Transaction after fully shipping an order

### DIFF
--- a/app/jobs/spree_stripe/create_tax_transaction_job.rb
+++ b/app/jobs/spree_stripe/create_tax_transaction_job.rb
@@ -1,0 +1,10 @@
+module SpreeStripe
+  class CreateTaxTransactionJob < ApplicationJob
+    def perform(store_id, payment_intent_id, tax_calculation_id)
+      store = Spree::Store.find(store_id)
+      gateway = store.stripe_gateway
+
+      gateway.create_tax_transaction(payment_intent_id, tax_calculation_id) if gateway.present?
+    end
+  end
+end

--- a/app/jobs/spree_stripe/create_tax_transaction_job.rb
+++ b/app/jobs/spree_stripe/create_tax_transaction_job.rb
@@ -1,5 +1,5 @@
 module SpreeStripe
-  class CreateTaxTransactionJob < ApplicationJob
+  class CreateTaxTransactionJob < BaseJob
     def perform(store_id, payment_intent_id, tax_calculation_id)
       store = Spree::Store.find(store_id)
       gateway = store.stripe_gateway

--- a/app/models/spree_stripe/gateway.rb
+++ b/app/models/spree_stripe/gateway.rb
@@ -59,11 +59,6 @@ module SpreeStripe
                      confirm_payment_intent(stripe_payment_intent.id)
                    end
 
-        # create a tax transaction if the order has a tax calculation
-        if order.stripe_tax_calculation_id.present?
-          create_tax_transaction(stripe_payment_intent.id, order.stripe_tax_calculation_id)
-        end
-
         success(response.id, response)
       end
     end

--- a/app/models/spree_stripe/shipment_decorator.rb
+++ b/app/models/spree_stripe/shipment_decorator.rb
@@ -1,0 +1,21 @@
+module SpreeStripe
+  module ShipmentDecorator
+    def self.prepended(base)
+      base.state_machine.after_transition to: :shipped, do: :create_tax_transaction_async
+    end
+
+    private
+
+    def create_tax_transaction_async
+      return unless order.fully_shipped?
+      return if order.stripe_tax_calculation_id.blank?
+
+      payment_intent = order.payment_intents.last
+      return if payment_intent.blank?
+
+      SpreeStripe::CreateTaxTransactionJob.perform_later(order.store_id, payment_intent.stripe_id, order.stripe_tax_calculation_id)
+    end
+  end
+end
+
+Spree::Shipment.prepend(SpreeStripe::ShipmentDecorator) if Spree::Shipment.included_modules.exclude?(SpreeStripe::ShipmentDecorator)

--- a/spec/jobs/spree_stripe/create_tax_transaction_job_spec.rb
+++ b/spec/jobs/spree_stripe/create_tax_transaction_job_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe SpreeStripe::CreateTaxTransactionJob do
+  subject { described_class.new.perform(store.id, payment_intent_id, tax_calculation_id) }
+
+  let(:store) { Spree::Store.default }
+  let(:payment_intent_id) { 'pi_1234567890' }
+  let(:tax_calculation_id) { 'taxcalc_1234567890' }
+
+  before do
+    allow(Stripe::Tax::Transaction).to receive(:create_from_calculation)
+  end
+
+  context 'when the stripe gateway is enabled' do
+    let!(:stripe_gateway) { create(:stripe_gateway, stores: [store]) }
+
+    it 'creates a tax transaction' do
+      subject
+
+      expect(Stripe::Tax::Transaction).to have_received(:create_from_calculation).with(
+        calculation: tax_calculation_id,
+        reference: payment_intent_id,
+        expand: ['line_items']
+      )
+    end
+  end
+
+  context 'when the stripe gateway is not enabled' do
+    it 'does not create a tax transaction' do
+      subject
+      expect(Stripe::Tax::Transaction).not_to have_received(:create_from_calculation)
+    end
+  end
+end

--- a/spec/models/spree_stripe/shipment_decorator_spec.rb
+++ b/spec/models/spree_stripe/shipment_decorator_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe SpreeStripe::ShipmentDecorator do
+  describe 'after_transition to :shipped' do
+    subject { shipment.ship! }
+
+    let(:store) { Spree::Store.default }
+    let(:order) { create(:order_ready_to_ship, payment_intents: payment_intents) }
+
+    let(:payment_intents) { [create(:payment_intent, stripe_id: payment_intent_id)] }
+    let(:payment_intent_id) { 'pi_1234567890' }
+    let(:tax_calculation_id) { 'taxcalc_1234567890' }
+
+    let(:shipment) { order.shipments.first }
+
+    before do
+      order.update(stripe_tax_calculation_id: tax_calculation_id)
+    end
+
+    context 'when the shipment is fully shipped' do
+      it 'creates a tax transaction' do
+        expect { subject }.to have_enqueued_job(SpreeStripe::CreateTaxTransactionJob).with(
+          store.id, payment_intent_id, tax_calculation_id
+        )
+      end
+
+      context 'when the shipment order has no stripe tax calculation id' do
+        let(:tax_calculation_id) { nil }
+
+        it 'does not create a tax transaction' do
+          expect { subject }.not_to have_enqueued_job(SpreeStripe::CreateTaxTransactionJob)
+        end
+      end
+
+      context 'when the shipment order has no payment intents' do
+        let(:payment_intents) { [] }
+
+        it 'does not create a tax transaction' do
+          expect { subject }.not_to have_enqueued_job(SpreeStripe::CreateTaxTransactionJob)
+        end
+      end
+    end
+
+    context 'when the shipment is not fully shipped' do
+      let!(:other_shipment) { create(:shipment, order: order, state: 'ready') }
+
+      it 'does not create a tax transaction' do
+        expect { subject }.not_to have_enqueued_job(SpreeStripe::CreateTaxTransactionJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically creates Stripe tax transactions when orders are fully shipped, improving post-shipment tax handling.
- Bug Fixes
  - Ensures tax calculations refresh correctly by incorporating updated line item amounts, reducing stale tax results.
- Changes
  - Moves tax transaction creation from payment authorization to shipment completion for more accurate timing.
- Tests
  - Added coverage for background job execution and shipment-triggered tax transaction behavior, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->