### PR TITLE
fix when spree_multi_store is not installed in project

### DIFF
--- a/app/services/spree_stripe/register_domain.rb
+++ b/app/services/spree_stripe/register_domain.rb
@@ -8,7 +8,7 @@ module SpreeStripe
       attributes_to_update = { stripe_apple_pay_domain_id: payment_method_domain.id }
 
       tld_length = model.url.split('.').length
-      if tld_length > 2 && model.is_a?(Spree::CustomDomain)
+      if tld_length > 2 && defined?(Spree::CustomDomain) && model.is_a?(Spree::CustomDomain)
         top_level_domain_name = model.url.split('.').last(tld_length - 1).join('.')
         top_level_domain = gateway.send_request { |opts| Stripe::PaymentMethodDomain.create({ domain_name: top_level_domain_name }, opts) }
         attributes_to_update[:stripe_top_level_domain_id] = top_level_domain.id


### PR DESCRIPTION
We have a safeguard here: https://github.com/spree/spree_stripe/blob/main/app/models/spree_stripe/gateway.rb#L339-L341
But `RegisterDomainJob` calls `Spree::CustomDomain` either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of Stripe domain registration by adding additional validation checks to prevent errors when specific prerequisites are not available in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->