### PR TITLE
Raise a gateway error when trying to create a zero amount payment session

### DIFF
--- a/app/models/spree_stripe/gateway/payment_sessions.rb
+++ b/app/models/spree_stripe/gateway/payment_sessions.rb
@@ -15,7 +15,7 @@ module SpreeStripe
         total = amount.presence || order.total_minus_store_credits
         amount_in_cents = Spree::Money.new(total, currency: order.currency).cents
 
-        return nil if amount_in_cents.zero?
+        raise Spree::Core::GatewayError, I18n.t('spree.stripe.payment_session_errors.zero_amount') if amount_in_cents.zero?
 
         customer = fetch_or_create_customer(order: order)
         stripe_pm_id = external_data[:stripe_payment_method_id] || external_data['stripe_payment_method_id']

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,3 +11,5 @@ en:
         requires_confirmation: Payment intent requires confirmation
         requires_payment_method: Payment intent requires payment method
         succeeded: Payment intent succeeded
+      payment_session_errors:
+        zero_amount: Payment session amount must be greater than zero

--- a/spec/models/spree_stripe/gateway/payment_sessions_spec.rb
+++ b/spec/models/spree_stripe/gateway/payment_sessions_spec.rb
@@ -83,9 +83,9 @@ RSpec.describe SpreeStripe::Gateway::PaymentSessions do
       expect(session.customer_external_id).to eq('cus_test_123')
     end
 
-    it 'returns nil when amount is zero' do
+    it 'raises a GatewayError when amount is zero' do
       allow(order).to receive(:total_minus_store_credits).and_return(0)
-      expect(subject).to be_nil
+      expect { subject }.to raise_error(Spree::Core::GatewayError, I18n.t('spree.stripe.payment_session_errors.zero_amount'))
     end
 
     context 'with a custom amount' do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes payment-session creation contract from nil to exception; callers must handle errors, but scope is small and aligned with existing GatewayError patterns.
> 
> **Overview**
> **Zero-amount payment sessions** no longer return `nil` from `create_payment_session` when the computed total (order total minus store credits, or an explicit `amount`) rounds to **0 cents**. The gateway now **raises `Spree::Core::GatewayError`** with a localized message (`spree.stripe.payment_session_errors.zero_amount`), so checkout code cannot proceed as if a session was created.
> 
> Specs were updated to expect the exception instead of `nil`. This is a **behavior change** for any caller that branched on a silent `nil`; they should rescue or handle `GatewayError` like other Stripe gateway failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a489f713d19610c607ff43c598d99fc4cc01dd1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Payment session processing now properly validates order amounts and displays a localized error message when the amount is zero.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree_stripe/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->