### PR TITLE
Fix deprecated valid_credit_cards method

### DIFF
--- a/lib/spree_api_v2/spree/api/v2/storefront/stripe/payment_intents_controller.rb
+++ b/lib/spree_api_v2/spree/api/v2/storefront/stripe/payment_intents_controller.rb
@@ -12,7 +12,10 @@ module Spree
               spree_authorize! :update, spree_current_order, order_token
 
               stripe_payment_method_id = permitted_attributes[:stripe_payment_method_id].presence
-              stripe_payment_method_id ||= spree_current_order.valid_credit_cards.where(payment_method: stripe_gateway).first&.gateway_payment_profile_id
+              stripe_payment_method_id ||= Spree::CreditCard.where(
+                id: spree_current_order.payments.from_credit_card.valid.select(:source_id),
+                payment_method: stripe_gateway
+              ).first&.gateway_payment_profile_id
 
               @payment_intent = SpreeStripe::CreatePaymentIntent.new.call(
                 spree_current_order,

--- a/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/stripe/payment_intents_spec.rb
@@ -64,6 +64,37 @@ RSpec.describe Spree::Api::V2::Storefront::Stripe::PaymentIntentsController, typ
       expect(payment_intent.client_secret).to eq(client_secret)
       expect(payment_intent.stripe_payment_method_id).to eq(stripe_payment_method_id)
     end
+
+    context 'when stripe_payment_method_id is not provided' do
+      let(:existing_profile_id) { 'pm_existing_1234567890' }
+      let(:credit_card) { create(:credit_card, payment_method: gateway, gateway_payment_profile_id: existing_profile_id) }
+      let(:params) do
+        {
+          payment_intent: {
+            amount: amount,
+            off_session: off_session
+          }
+        }
+      end
+  
+      before do
+        order.update(total: amount)
+        create(:payment, order: order, payment_method: gateway, source: credit_card, amount: amount, state: 'checkout')
+  
+        allow_any_instance_of(gateway.class).to receive(:create_payment_intent)
+          .with(Spree::Money.new(amount).cents, order, payment_method_id: existing_profile_id, off_session: off_session)
+          .and_return(stripe_response)
+  
+        post '/api/v2/storefront/stripe/payment_intents', headers: headers, params: params
+      end
+  
+      include_context 'returns 200 HTTP status'
+  
+      it "falls back to the gateway payment profile id of the order's existing stripe credit card" do
+        expect(payment_intent).to be_present
+        expect(payment_intent.stripe_payment_method_id).to eq(existing_profile_id)
+      end
+    end
   end
 
   describe 'payment_intents#update' do


### PR DESCRIPTION
Error: https://vendo-connect.sentry.io/issues/7538826991/?project=4509685278179328&query=is%3Aunresolved&referrer=issue-stream

undefined method `valid_credit_cards' for an instance of Spree::Order (NoMethodError)

`valid_credit_cards` was removed from spree, replaced it with code representic same logic: https://github.com/spree/spree/blob/v5.3.5/core/app/models/spree/order.rb#L516-L519

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout payment-intent creation and saved-card resolution; behavior should match Spree’s replacement logic but wrong scoping could pick the wrong Stripe PM.
> 
> **Overview**
> Fixes a **NoMethodError** on Stripe payment intent creation after Spree removed `Order#valid_credit_cards`.
> 
> When `stripe_payment_method_id` is omitted, the storefront **create** action now resolves the Stripe payment method by loading credit cards tied to the order’s **valid credit-card payments** (via `payments.from_credit_card.valid`) and filtering to the Stripe gateway, then using the first card’s `gateway_payment_profile_id`.
> 
> A request spec covers this fallback path with an existing checkout payment and saved card on the order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e24fb93d0cbc988ab8e831f0c2e4c602854e446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe payment processing: the system now automatically uses an existing saved credit card when a specific payment method is not explicitly provided during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->