### PR TITLE
LUP-6 Guard against missing legacy API v2

### DIFF
--- a/app/views/spree/checkout/payment/_spree_stripe.html.erb
+++ b/app/views/spree/checkout/payment/_spree_stripe.html.erb
@@ -1,3 +1,5 @@
+<%# The Stripe storefront payment flow depends on the legacy Storefront API v2 %>
+<% if defined?(SpreeLegacyApiV2::Engine) %>
 <div
   data-controller="checkout-stripe"
   data-checkout-stripe-payment-intent-value="<%= current_stripe_payment_intent.to_json %>"
@@ -64,3 +66,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/spree_stripe/_quick_checkout.html.erb
+++ b/app/views/spree_stripe/_quick_checkout.html.erb
@@ -1,4 +1,5 @@
-<% if quick_checkout_enabled?(@order) && current_stripe_gateway.present? && current_stripe_payment_intent.present? %>
+<%# The Stripe storefront payment flow depends on the legacy Storefront API v2 %>
+<% if defined?(SpreeLegacyApiV2::Engine) && quick_checkout_enabled?(@order) && current_stripe_gateway.present? && current_stripe_payment_intent.present? %>
   <div id="quick-checkout" class="<%= defined?(container_class) ? container_class : nil %>">
     <%= tag.div class: 'w-full', data: {
         controller: 'checkout-stripe-button',

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -4,6 +4,10 @@ Rails.application.config.after_initialize do
 
   if Rails.application.config.respond_to?(:spree_storefront)
     Rails.application.config.spree_storefront.head_partials << 'spree_stripe/head'
-    Rails.application.config.spree_storefront.quick_checkout_partials << 'spree_stripe/quick_checkout'
+
+    # Quick checkout partial depends on the legacy Storefront API v2
+    if defined?(SpreeLegacyApiV2::Engine)
+      Rails.application.config.spree_storefront.quick_checkout_partials << 'spree_stripe/quick_checkout'
+    end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Conditional rendering only; when legacy API v2 is present behavior is unchanged, and when absent Stripe storefront UI is intentionally hidden instead of erroring.
> 
> **Overview**
> Stripe checkout and quick-checkout storefront UI are now **only rendered when `SpreeLegacyApiV2::Engine` is loaded**, because those flows call Storefront API v2 routes (e.g. payment intent and checkout paths).
> 
> The checkout Stripe payment partial is wrapped in that guard, quick checkout adds the same check alongside its existing enablement conditions, and the `spree.rb` initializer **only registers** the quick-checkout partial when the engine is defined—avoiding broken partials or route helpers when legacy API v2 is not in the bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddb3a526a482631540b2c0fd5983b1e27d12cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->