### PR TITLE
Don't hardcode cart path in JS controllers, fix selecting shipping rate on quick checkout

### DIFF
--- a/app/helpers/spree_stripe/base_helper.rb
+++ b/app/helpers/spree_stripe/base_helper.rb
@@ -21,6 +21,13 @@ module SpreeStripe
       "cart_#{Spree::PrefixedId::SQIDS.encode([order.id])}"
     end
 
+    # Server-generated v3 Store API path for the order's cart, passed to the
+    # storefront JS so proxied/prefixed deployments resolve the API correctly.
+    # @return [String]
+    def stripe_cart_api_path(order)
+      spree.api_v3_store_cart_path(stripe_cart_prefixed_id(order))
+    end
+
     # The store's publishable Spree API key, used by the storefront JS as the
     # `X-Spree-API-Key` header for v3 Store API calls. Creates one on first use
     # when the store has no active publishable key yet.

--- a/app/javascript/spree_stripe/controllers/stripe_button_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_button_controller.js
@@ -10,15 +10,16 @@ const ZERO_DECIMAL_CURRENCIES = new Set([
 ])
 
 // Apple Pay / Google Pay express checkout on the v3 Store API. The wallet sheet
-// drives address + shipping selection against `/api/v3/store/carts`, then a
-// payment session is created and confirmed; completion is handled server-side by
-// ConfirmPaymentsController via the `return_url` (same as the regular flow).
+// drives address + shipping selection against the server-provided cart API
+// path, then a payment session is created and confirmed; completion is handled
+// server-side by ConfirmPaymentsController via the `return_url` (same as the
+// regular flow).
 export default class extends Controller {
   static values = {
     apiKey: String,
     spreeApiKey: String,
     paymentMethodId: String,
-    cartId: String,
+    cartApiPath: String,
     cartToken: String,
     confirmPaymentUrl: String,
     currency: String,
@@ -38,6 +39,7 @@ export default class extends Controller {
   connect() {
     this.isGooglePay = false
     this.shippingRateMap = new Map()
+    this.deliveryMethodMap = new Map()
     this.initStripe()
   }
 
@@ -139,8 +141,9 @@ export default class extends Controller {
       })
       if (!cart) return event.reject()
 
-      const { shippingRates, selectionMap } = this.buildShippingRates(cart.fulfillments || [])
+      const { shippingRates, selectionMap, methodMap } = this.buildShippingRates(cart.fulfillments || [])
       this.shippingRateMap = selectionMap
+      this.deliveryMethodMap = methodMap
 
       if (shippingRates.length === 0) return event.reject()
 
@@ -215,6 +218,17 @@ export default class extends Controller {
       return
     }
 
+    // The address patch above rebuilds fulfillments with their default rate,
+    // discarding the wallet's selection — re-select it before charging, or the
+    // order completes with the wrong delivery method and total.
+    if (this.shippingRequiredValue && event.shippingRate) {
+      const reselected = await this.reselectDeliveryRates(cart, event.shippingRate.id)
+      if (!reselected) {
+        event.paymentFailed({ reason: 'fail' })
+        return
+      }
+    }
+
     const { error: submitError } = await this.elements.submit()
     if (submitError) {
       event.paymentFailed({ reason: 'fail' })
@@ -259,7 +273,7 @@ export default class extends Controller {
   // --- v3 Store API calls -------------------------------------------------
 
   async patchCart(body) {
-    const response = await fetch(this.cartApiBase, {
+    const response = await fetch(this.cartApiPathValue, {
       method: 'PATCH',
       headers: this.spreeApiHeaders,
       body: JSON.stringify(body)
@@ -268,7 +282,7 @@ export default class extends Controller {
   }
 
   async patchFulfillment(fulfillmentId, deliveryRateId) {
-    const response = await fetch(`${this.cartApiBase}/fulfillments/${fulfillmentId}`, {
+    const response = await fetch(`${this.cartApiPathValue}/fulfillments/${fulfillmentId}`, {
       method: 'PATCH',
       headers: this.spreeApiHeaders,
       body: JSON.stringify({ selected_delivery_rate_id: deliveryRateId })
@@ -277,7 +291,7 @@ export default class extends Controller {
   }
 
   async createPaymentSession(stripePaymentMethodId) {
-    const response = await fetch(`${this.cartApiBase}/payment_sessions`, {
+    const response = await fetch(`${this.cartApiPathValue}/payment_sessions`, {
       method: 'POST',
       headers: this.spreeApiHeaders,
       body: JSON.stringify({
@@ -304,11 +318,14 @@ export default class extends Controller {
     return items
   }
 
-  // Builds deduped Stripe shipping rates (by delivery_method_id) and a map from
-  // each Stripe rate id to the per-fulfillment delivery rate ids to select.
+  // Builds deduped Stripe shipping rates (by delivery_method_id), a map from
+  // each Stripe rate id to the per-fulfillment delivery rate ids to select,
+  // and a map back to the delivery_method_id (the only id that survives a
+  // fulfillment rebuild — see reselectDeliveryRates).
   buildShippingRates(fulfillments) {
     const rateMap = new Map()
     const selectionMap = new Map()
+    const methodMap = new Map()
 
     for (const fulfillment of fulfillments) {
       for (const rate of fulfillment.delivery_rates || []) {
@@ -320,6 +337,7 @@ export default class extends Controller {
           const id = this.isGooglePay ? `${methodId}-${this.randomSuffix()}` : String(methodId)
           rateMap.set(methodId, { id, displayName: rate.name, amount: this.toCents(rate.cost) })
           selectionMap.set(id, [])
+          methodMap.set(id, methodId)
         } else {
           rateMap.get(methodId).amount += this.toCents(rate.cost)
         }
@@ -329,7 +347,26 @@ export default class extends Controller {
       }
     }
 
-    return { shippingRates: Array.from(rateMap.values()), selectionMap }
+    return { shippingRates: Array.from(rateMap.values()), selectionMap, methodMap }
+  }
+
+  // Re-selects the delivery method chosen in the wallet sheet on freshly
+  // rebuilt fulfillments. Matches by delivery_method_id: fulfillment and rate
+  // ids do not survive the rebuild that a shipping-address update triggers
+  // server-side (checkout reverts to the address step and shipments are
+  // recreated with their default rate).
+  async reselectDeliveryRates(cart, stripeRateId) {
+    const methodId = this.deliveryMethodMap.get(stripeRateId)
+    if (!methodId) return false
+
+    for (const fulfillment of cart.fulfillments || []) {
+      const rate = (fulfillment.delivery_rates || []).find((r) => r.delivery_method_id === methodId)
+      if (!rate || rate.selected) continue
+
+      const updated = await this.patchFulfillment(fulfillment.id, rate.id)
+      if (!updated) return false
+    }
+    return true
   }
 
   // True when every shippable fulfillment has at least one delivery rate — i.e.
@@ -382,10 +419,6 @@ export default class extends Controller {
     } else {
       showFlashMessage('An unexpected error occurred. Please refresh the page and try again.', 'error')
     }
-  }
-
-  get cartApiBase() {
-    return `/api/v3/store/carts/${this.cartIdValue}`
   }
 
   get spreeApiHeaders() {

--- a/app/javascript/spree_stripe/controllers/stripe_controller.js
+++ b/app/javascript/spree_stripe/controllers/stripe_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
   static values = {
     apiKey: String,
     clientSecret: String,
-    cartId: String,
+    cartApiPath: String,
     cartToken: String,
     spreeApiKey: String,
     orderEmail: String,
@@ -134,7 +134,7 @@ export default class extends Controller {
       return false
     }
 
-    const response = await fetch(this.cartApiBase, {
+    const response = await fetch(this.cartApiPathValue, {
       method: 'PATCH',
       headers: this.spreeApiHeaders,
       body: JSON.stringify(body)
@@ -222,10 +222,6 @@ export default class extends Controller {
       return Array.isArray(json.errors) ? json.errors.join('. ') : Object.values(json.errors).flat().join('. ')
     }
     return null
-  }
-
-  get cartApiBase() {
-    return `/api/v3/store/carts/${this.cartIdValue}`
   }
 
   get spreeApiHeaders() {

--- a/app/views/spree/checkout/payment/_spree_stripe.html.erb
+++ b/app/views/spree/checkout/payment/_spree_stripe.html.erb
@@ -3,7 +3,7 @@
     data-controller="checkout-stripe"
     data-checkout-stripe-api-key-value="<%= current_stripe_gateway.try(:preferred_publishable_key) %>"
     data-checkout-stripe-client-secret-value="<%= current_stripe_payment_session.client_secret %>"
-    data-checkout-stripe-cart-id-value="<%= stripe_cart_prefixed_id(@order) %>"
+    data-checkout-stripe-cart-api-path-value="<%= stripe_cart_api_path(@order) %>"
     data-checkout-stripe-cart-token-value="<%= @order.token %>"
     data-checkout-stripe-spree-api-key-value="<%= current_store_publishable_api_key %>"
     data-checkout-stripe-order-email-value="<%= @order.email %>"

--- a/app/views/spree_stripe/_quick_checkout.html.erb
+++ b/app/views/spree_stripe/_quick_checkout.html.erb
@@ -6,7 +6,7 @@
         checkout_stripe_button_api_key_value: current_stripe_gateway.try(:preferred_publishable_key),
         checkout_stripe_button_spree_api_key_value: current_store_publishable_api_key,
         checkout_stripe_button_payment_method_id_value: current_stripe_gateway.prefixed_id,
-        checkout_stripe_button_cart_id_value: stripe_cart_prefixed_id(@order),
+        checkout_stripe_button_cart_api_path_value: stripe_cart_api_path(@order),
         checkout_stripe_button_cart_token_value: @order.token,
         checkout_stripe_button_confirm_payment_url_value: spree.stripe_confirm_payment_url(@order.prefixed_id),
         checkout_stripe_button_currency_value: @order.currency.downcase,

--- a/spec/helpers/spree_stripe/base_helper_spec.rb
+++ b/spec/helpers/spree_stripe/base_helper_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe SpreeStripe::BaseHelper do
     end
   end
 
+  describe '#stripe_cart_api_path' do
+    it 'returns the v3 store cart API path for the order' do
+      expect(helper.stripe_cart_api_path(order)).to eq("/api/v3/store/carts/#{helper.stripe_cart_prefixed_id(order)}")
+    end
+  end
+
   describe '#current_store_publishable_api_key' do
     it "returns the store's active publishable key token" do
       key = create(:api_key, store: store)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe checkout compatibility with proxied or prefixed storefront deployments.
  * Preserved selected shipping methods when express checkout addresses are updated.
  * Ensured billing and delivery selections are correctly restored before payment submission.
  * Rejects wallet payments when the selected shipping option cannot be restored.

* **Tests**
  * Added coverage for generating Stripe cart API paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->