### PR TITLE
Require spree >= 5.6.0 for credit card fingerprint dedup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,15 +14,7 @@ spree_opts = if ENV['SPREE_PATH']
              end
 gem 'spree', spree_opts
 
-# spree_admin pinned to the commit before spree#14287, which added a
-# Spree::Admin::StorefrontController + `admin_storefront` route that collides
-# with spree_page_builder's. Revert to spree_opts once upstream deconflicts.
-spree_admin_opts = if ENV['SPREE_PATH']
-                      { 'path': ENV['SPREE_PATH'] }
-                   else
-                      { 'github': 'spree/spree', 'ref': '2174f67734f523207bb90d6cdf4eb7463619af52', 'glob': 'spree/admin/*.gemspec' }
-                   end
-gem 'spree_admin', spree_admin_opts
+gem 'spree_admin', spree_opts
 
 gem 'spree_custom_domains', github: 'spree/spree_custom_domains', branch: 'main'
 

--- a/spree_stripe.gemspec
+++ b/spree_stripe.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '>= 5.4.0.beta'
+  spree_version = '>= 5.6.0'
   s.add_dependency 'spree', spree_version
   s.add_dependency 'spree_admin', spree_version
 


### PR DESCRIPTION
The duplicate-card fix (#72) moved its dedup machinery into spree core and now depends on it: the `fingerprint` column + unique index on spree_credit_cards, the `by_fingerprint` scope, and the `wallet`/`wallet_type` accessors on Spree::CreditCard. Those landed in spree core via #14281 on 2026-07-07 and first shipped in the stable 5.6.0 release (2026-07-23) — they are absent from 5.4.x and 5.5.x (including the 5.5.4 patch).

The gemspec still declared `>= 5.4.0.beta`, which a real released 5.4.x/5.5.0 would satisfy while lacking the column/scope/accessors — CreateSource would raise on card save and the checkout helper would NoMethodError on wallet_type. Bump the floor to the version that actually contains the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Spree and Spree Admin version to 5.6.0.
  * Older beta and pre-release versions are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->