### PR TITLE
Backport credit card fingerprint dedup for spree < 5.6.0

### DIFF
--- a/app/models/spree_stripe/credit_card_decorator.rb
+++ b/app/models/spree_stripe/credit_card_decorator.rb
@@ -1,0 +1,49 @@
+module SpreeStripe
+  # Backports Stripe's credit-card fingerprint dedup onto Spree::CreditCard for
+  # spree < 5.6.0, which doesn't ship it. spree >= 5.6.0 provides the column,
+  # scope, and validation in core, so this is only prepended (below) when core
+  # lacks it. (Wallet metadata accessors already live in core since 5.4, so they
+  # don't need backporting here.)
+  module CreditCardDecorator
+    def self.prepended(base)
+      # Matches saved cards by the gateway's stable card fingerprint plus expiry,
+      # used to reuse an existing card instead of saving a duplicate when a gateway
+      # issues a fresh payment method id for the same physical card.
+      #
+      # @param fingerprint [String] gateway card fingerprint
+      # @param month [Integer, String] expiry month
+      # @param year [Integer, String] expiry year
+      base.scope :by_fingerprint, ->(fingerprint, month, year) {
+        cards_table = Spree::CreditCard.table_name
+
+        where(fingerprint: fingerprint).
+          where("CAST(#{cards_table}.month AS DECIMAL) = ?", month).
+          where("CAST(#{cards_table}.year AS DECIMAL) = ?", year)
+      }
+
+      # Prevents saving the same physical card (same gateway fingerprint + expiry)
+      # twice for a user and payment method. Skipped when the gateway does not
+      # provide a fingerprint.
+      base.validate :fingerprint_not_duplicated, if: -> { fingerprint.present? }
+    end
+
+    private
+
+    # month/year are varchar columns exposed as integer attributes, so the
+    # match must go through #by_fingerprint's decimal cast rather than a plain
+    # equality (which Postgres rejects as `character varying = integer`).
+    def fingerprint_not_duplicated
+      duplicates = self.class.where(user_id: user_id, payment_method_id: payment_method_id).
+                   by_fingerprint(fingerprint, month, year)
+      duplicates = duplicates.where.not(id: id) if persisted?
+
+      errors.add(:fingerprint, :taken) if duplicates.exists?
+    end
+  end
+end
+
+# spree >= 5.6.0 ships fingerprint dedup in core, so only prepend the backport
+# when it's absent (spree < 5.6.0).
+unless Spree::CreditCard.respond_to?(:by_fingerprint)
+  Spree::CreditCard.prepend(SpreeStripe::CreditCardDecorator)
+end

--- a/db/migrate/20260610120000_add_fingerprint_to_spree_credit_cards.rb
+++ b/db/migrate/20260610120000_add_fingerprint_to_spree_credit_cards.rb
@@ -38,6 +38,14 @@ class AddFingerprintToSpreeCreditCards < ActiveRecord::Migration[7.2]
   end
 
   def down
+    # From spree 5.6.0 the fingerprint column AND its unique index live in core (both
+    # share the same names), and Rails' migration installer dedupes this migration
+    # against core's — so on 5.6.0+ this migration never created them. Leave core's
+    # schema untouched there, which also covers an app that added the column here on
+    # older spree and later upgraded: the column is now core-owned and must survive
+    # a rollback.
+    return if Gem::Version.new(Spree.version) >= Gem::Version.new('5.6.0')
+
     remove_index :spree_credit_cards, name: INDEX_NAME if index_name_exists?(:spree_credit_cards, INDEX_NAME)
     remove_column :spree_credit_cards, :fingerprint if column_exists?(:spree_credit_cards, :fingerprint)
   end

--- a/db/migrate/20260610120000_add_fingerprint_to_spree_credit_cards.rb
+++ b/db/migrate/20260610120000_add_fingerprint_to_spree_credit_cards.rb
@@ -1,0 +1,44 @@
+class AddFingerprintToSpreeCreditCards < ActiveRecord::Migration[7.2]
+  INDEX_NAME = 'index_spree_credit_cards_unique_fingerprint'.freeze
+
+  # spree >= 5.6.0 ships this same migration in core (same name, so Rails' migration
+  # installer skips this copy). On spree < 5.6.0 it runs here, giving the gateway a
+  # place to store Stripe's card fingerprint for dedup. Guarded so it stays a no-op
+  # if the column/index already exist.
+  def up
+    add_column :spree_credit_cards, :fingerprint, :string, if_not_exists: true
+
+    return if index_name_exists?(:spree_credit_cards, INDEX_NAME)
+
+    # Prevent duplicate saved cards (same gateway fingerprint + expiry) per user and
+    # payment method at the database level. Only active, fingerprinted cards are
+    # constrained, so legacy/non-gateway cards (NULL fingerprint) and soft-deleted
+    # rows are left untouched.
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      # MySQL has no partial indexes, but treats NULL as distinct in unique indexes,
+      # so NULL fingerprints are naturally allowed. COALESCE on deleted_at keeps
+      # soft-deleted rows from colliding with active ones.
+      execute <<-SQL
+        CREATE UNIQUE INDEX #{INDEX_NAME}
+        ON spree_credit_cards(
+          user_id,
+          payment_method_id,
+          fingerprint,
+          month,
+          year,
+          (COALESCE(deleted_at, CAST('1970-01-01' AS DATETIME)))
+        )
+      SQL
+    else
+      add_index :spree_credit_cards, [:user_id, :payment_method_id, :fingerprint, :month, :year],
+                unique: true,
+                where: 'fingerprint IS NOT NULL AND deleted_at IS NULL',
+                name: INDEX_NAME
+    end
+  end
+
+  def down
+    remove_index :spree_credit_cards, name: INDEX_NAME if index_name_exists?(:spree_credit_cards, INDEX_NAME)
+    remove_column :spree_credit_cards, :fingerprint if column_exists?(:spree_credit_cards, :fingerprint)
+  end
+end

--- a/spec/models/spree_stripe/credit_card_decorator_spec.rb
+++ b/spec/models/spree_stripe/credit_card_decorator_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe SpreeStripe::CreditCardDecorator, type: :model do
+  describe '.by_fingerprint' do
+    let!(:match) { create(:credit_card, fingerprint: 'FZqjhq46SWprIY8i', month: 2, year: 2030) }
+    let!(:other_fingerprint) { create(:credit_card, fingerprint: 'differentFingerprint', month: 2, year: 2030) }
+    let!(:other_expiry) { create(:credit_card, fingerprint: 'FZqjhq46SWprIY8i', month: 12, year: 2031) }
+
+    it 'returns cards matching the fingerprint and expiry' do
+      expect(Spree::CreditCard.by_fingerprint('FZqjhq46SWprIY8i', 2, 2030)).to contain_exactly(match)
+    end
+
+    it 'matches when month and year are passed as strings' do
+      expect(Spree::CreditCard.by_fingerprint('FZqjhq46SWprIY8i', '2', '2030')).to contain_exactly(match)
+    end
+
+    it 'returns nothing when the expiry differs' do
+      expect(Spree::CreditCard.by_fingerprint('FZqjhq46SWprIY8i', 1, 2030)).to be_empty
+    end
+  end
+
+  describe 'fingerprint uniqueness' do
+    let(:user) { create(:user) }
+    let(:payment_method) { create(:stripe_gateway) }
+    let!(:existing) do
+      create(:credit_card, user: user, payment_method: payment_method,
+                           fingerprint: 'FZqjhq46SWprIY8i', month: 2, year: 2030)
+    end
+
+    it 'rejects a second card with the same fingerprint and expiry for the user and payment method' do
+      duplicate = build(:credit_card, user: user, payment_method: payment_method,
+                                      fingerprint: 'FZqjhq46SWprIY8i', month: 2, year: 2030)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:fingerprint]).to be_present
+    end
+
+    it 'allows the same fingerprint with a different expiry' do
+      other = build(:credit_card, user: user, payment_method: payment_method,
+                                  fingerprint: 'FZqjhq46SWprIY8i', month: 12, year: 2031)
+
+      expect(other).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
The duplicate-card fix relies on fingerprint dedup that shipped in spree core 5.6.0 — the `fingerprint` column, the `by_fingerprint` scope, and the `fingerprint_not_duplicated` validation on Spree::CreditCard. Since the gemspec still supports spree >= 5.4.0.beta, provide that machinery from the gem on older spree, guarded so it's a no-op on 5.6.0+ where core already ships it:

- Migration: adds the `fingerprint` column (if_not_exists) + the same unique partial index as core. It shares core's migration name, so Rails' migration installer dedupes it on 5.6.0 (core's copy wins) and it only runs standalone on spree < 5.6.0.
- Decorator: prepends the `by_fingerprint` scope + `fingerprint_not_duplicated` validation only when core lacks them (`unless respond_to?(:by_fingerprint)`). Wallet accessors are left to core, which has shipped them since 5.4.
- Spec: covers the scope and the dedup validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevented duplicate saved Stripe credit cards by fingerprint, payment method, and expiration (month/year).
  * Added fingerprint-based lookup that matches stored cards against provided fingerprint and expiration details.
* **Bug Fixes**
  * Enforced uniqueness only for active (non-deleted) cards and ignored legacy cards without fingerprints.
* **Tests**
  * Added model specs covering fingerprint matching and duplicate-card prevention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->