### PR TITLE
V-3523 swtich spree branch to 5-6-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails-controller-testing'
 spree_opts = if ENV['SPREE_PATH']
                 { 'path': ENV['SPREE_PATH'] }
              else
-                { 'github': 'spree/spree', 'branch': 'main', 'glob': 'spree/**/*.gemspec' }
+                { 'github': 'spree/spree', 'branch': '5-6-stable', 'glob': 'spree/**/*.gemspec' }
              end
 gem 'spree', spree_opts
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tracks a stable release line instead of Spree main, which can change app behavior and require bundle/test validation; admin remains on a separate pinned ref.
> 
> **Overview**
> Points the main **`spree`** dependency at GitHub branch **`5-6-stable`** instead of **`main`** when `SPREE_PATH` is not set.
> 
> **`spree_admin`** stays on the existing commit pin (route collision with `spree_page_builder`); storefront and other Spree-related gems are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd92160bc7f6d50516d086e71a3fa54af288a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Spree dependency source to use the stable 5-6 branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->